### PR TITLE
fix: correct groupId for fress in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <version>0.8.256</version>
     </dependency>
     <dependency>
-      <groupId>com.cognitect</groupId>
+      <groupId>fress</groupId>
       <artifactId>fress</artifactId>
       <version>0.3.1</version>
     </dependency>


### PR DESCRIPTION
This fixes an issue with downstream builds. As the fress library was associated with the com.cognitect groupId